### PR TITLE
add defaults and enable compressed property dictionary

### DIFF
--- a/feincms3_meta/fields.py
+++ b/feincms3_meta/fields.py
@@ -1,19 +1,32 @@
+from django.conf import settings
+
+
 class StructuredDataProperty:
-    def __init__(self, attribute, property, keyword="@value"):
-        self.attribute = attribute
+    def __init__(self, property, value=None, keyword=None):
         self.property = property
+        self.value = value
         self.keyword = keyword
 
 
+DEFAULT_PROPERTIES = getattr(
+    settings,
+    "DEFAULT_STRUCTURED_DATA_PROPERTIES",
+    [
+        StructuredDataProperty("@context", "https://schema.org/"),
+        StructuredDataProperty("@type", "WebPageElement"),
+    ],
+)
+
+
 class StructuredDataField(StructuredDataProperty):
-    def __init__(self, field, *args, fallback="", **kwargs):
+    def __init__(self, field, property, *args, fallback="", **kwargs):
         self.field = field
         self.fallback = fallback
-        super().__init__(field, *args, **kwargs)
+        super().__init__(property, *args, **kwargs)
 
     def contribute_to_class(self, cls, name):
         self.field.contribute_to_class(cls, name)
-        self.attribute = lambda obj: (
+        self.value = lambda obj: (
             getattr(obj, name)
             or (
                 getattr(obj, self.fallback)
@@ -21,8 +34,5 @@ class StructuredDataField(StructuredDataProperty):
                 else None
             )
         )
-
-        if not hasattr(cls, "structured_data_properties"):
-            cls.structured_data_properties = []
 
         cls.structured_data_properties.append(self)

--- a/feincms3_meta/utils.py
+++ b/feincms3_meta/utils.py
@@ -6,7 +6,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.html import (
     _json_script_escapes,
     escape,
-    format_html,
     html_safe,
     mark_safe,
 )
@@ -134,8 +133,5 @@ def meta_tags(objects=(), *, request, defaults=None, **kwargs):
     ).add(getattr(settings, "META_TAGS", None), defaults, *reversed(objects), **kwargs)
 
 
-def escaped_json_to_html(html_template, json_data):
-    json_str = json.dumps(json_data, cls=DjangoJSONEncoder).translate(
-        _json_script_escapes
-    )
-    return format_html(html_template, *(mark_safe(json_str),))
+def escape_json(json_data):
+    return json.dumps(json_data, cls=DjangoJSONEncoder).translate(_json_script_escapes)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -9,14 +9,20 @@ class Model(MetaMixin):
     pass
 
 
-class StructuredDataModel(StructuredDataMixin):
+class NaiveStructuredDataModel(StructuredDataMixin):
     name = StructuredDataField(
         models.CharField(max_length=50), "https://schema.org/name"
     )
+
+
+class StructuredDataModel(StructuredDataMixin):
+    name = StructuredDataField(models.CharField(max_length=50), "name")
 
     def get_absolute_url(self):
         return "/slug/"
 
     structured_data_properties = [
-        StructuredDataProperty(get_absolute_url, "https://schema.org/url", "@id")
+        StructuredDataProperty("@context", "https://schema.org/"),
+        StructuredDataProperty("@type", "WebPageElement"),
+        StructuredDataProperty("url", get_absolute_url, "@id"),
     ]

--- a/tests/testapp/test_meta.py
+++ b/tests/testapp/test_meta.py
@@ -234,7 +234,7 @@ class MetaTest(test.TestCase):
         self.assertEqual(
             str(m.structured_data()),
             """\
-<script type="application/ld+json">{"https://schema.org/title": {"@value": "title-test"}, "https://schema.org/description": {"@value": "description-test"}}</script>""",
+<script type="application/ld+json">{"@context": "https://schema.org/", "@type": "WebPage", "title": "title-test", "description": "description-test"}</script>""",
         )
 
     def test_expanded_json_ld_fallback_test(self):
@@ -243,14 +243,22 @@ class MetaTest(test.TestCase):
         self.assertEqual(
             str(m.structured_data()),
             """\
-<script type="application/ld+json">{"https://schema.org/title": {"@value": "fallback-title-test"}}</script>""",
+<script type="application/ld+json">{"@context": "https://schema.org/", "@type": "WebPage", "title": "fallback-title-test"}</script>""",
         )
 
     def test_expanded_json_ld_from_custom_model(self):
+        #         m = NaiveStructuredDataModel()
+        #         m.name = "test-name"
+        #         self.assertEqual(
+        #             str(m.structured_data()),
+        #             """\
+        # <script type="application/ld+json">{"@context": "https://schema.org/", "@type": "WebPageElement", "url": {"@id": "/slug/"}, "name": "test-name"}</script>""",
+        #         )
+
         m = StructuredDataModel()
-        m.name = "name"
+        m.name = "test-name"
         self.assertEqual(
             str(m.structured_data()),
             """\
-<script type="application/ld+json">{"https://schema.org/url": {"@id": "/slug/"}, "https://schema.org/name": {"@value": "name"}}</script>""",
+<script type="application/ld+json">{"@context": "https://schema.org/", "@type": "WebPageElement", "url": {"@id": "/slug/"}, "name": "test-name"}</script>""",
         )


### PR DESCRIPTION
Added defaults, since "type" property seems to be necessary, at least for the validators on schema.org and google.
A refactor for structured data properties also makes it possible to set a "context" property, which is reasonable anyway.